### PR TITLE
Add total active power

### DIFF
--- a/tesla_wall_connector/vitals.py
+++ b/tesla_wall_connector/vitals.py
@@ -139,6 +139,14 @@ class Vitals:
         return self.raw_data["evse_state"]
 
     @property
+    def total_power_w(self) -> float:
+        """Total power calculated from three phases"""
+        return round(
+            (self.voltageA_v * self.currentA_a) +
+            (self.voltageB_v * self.currentB_a) +
+            (self.voltageC_v * self.currentC_a), 1)
+
+    @property
     def current_alerts(self) -> typing.List[str]:
         """Current alerts"""
         return self.raw_data["current_alerts"]

--- a/tests/test_wall_connector.py
+++ b/tests/test_wall_connector.py
@@ -45,6 +45,7 @@ async def test_vitals_request(aresponses):
         assert vitals.config_status == 5
         assert vitals.evse_state == 1
         assert vitals.current_alerts == ["alert1", "alert2"]
+        assert vitals.total_power_w == 241.7
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Proposed change

This library currently provides per-phase voltage and current information. I would find it useful if it would also provide total active power, which can be calculated from voltages/currents. I propose to add a calculated property for that. 

_This PR was created with the help of the Claude AI. [Tag1 consulting](https://tag1.com) sponsored my time to work in this feature._

I initially added this to [Home Assistant core](https://github.com/home-assistant/core/pull/151028), but was instructed to add it here instead. 
