### PR TITLE
Add split phase option for total power (#18)

### DIFF
--- a/tesla_wall_connector/vitals.py
+++ b/tesla_wall_connector/vitals.py
@@ -9,9 +9,10 @@ import typing
 class Vitals:
     """Object holding 'vitals' data for a Tesla Wall Connector"""
 
-    def __init__(self, raw_data: dict):
+    def __init__(self, raw_data: dict, split_phase: bool = False):
         """Return a new Vitals object from Tesla Wall Connector API response"""
         self.raw_data = raw_data
+        self.split_phase = split_phase
 
     @property
     def contactor_closed(self) -> bool:
@@ -155,14 +156,6 @@ class Vitals:
         return self.raw_data["evse_state"]
 
     @property
-    def total_power_w(self) -> float:
-        """Total power calculated from three phases"""
-        return round(
-            (self.voltageA_v * self.currentA_a) +
-            (self.voltageB_v * self.currentB_a) +
-            (self.voltageC_v * self.currentC_a), 1)
-
-    @property
     def current_alerts(self) -> typing.List[str]:
         """Current alerts"""
         return self.raw_data["current_alerts"]
@@ -171,3 +164,16 @@ class Vitals:
     def evse_not_ready_reasons(self) -> typing.List[int]:
         """Reasons for EVSE not being ready."""
         return self.raw_data.get("evse_not_ready_reasons", [])
+
+    @property
+    def total_power_w(self) -> float:
+        """Total power calculated from either split-phase or three-phase input"""
+        if self.split_phase:
+            return round(self.grid_v * self.vehicle_current_a, 1)
+
+        total_power = (
+            (self.voltageA_v * self.currentA_a) +
+            (self.voltageB_v * self.currentB_a) +
+            (self.voltageC_v * self.currentC_a)
+        )
+        return round(total_power, 1)

--- a/tesla_wall_connector/wall_connector.py
+++ b/tesla_wall_connector/wall_connector.py
@@ -12,15 +12,25 @@ from .wifi_status import WifiStatus
 class WallConnector:
     """Main class for reading data from a Tesla Wall Connector"""
 
-    def __init__(self, host: str, timeout: float = 1, session: ClientSession = None):
+    def __init__(
+        self,
+        host: str,
+        timeout: float = 1,
+        session: ClientSession = None,
+        split_phase: bool = False,
+    ):
         if session is None:
             session = ClientSession()
             self._session = session
         self.api = API(host, session, timeout)
+        self.split_phase = split_phase
 
     async def async_get_vitals(self) -> dict:
         """Get 'vitals' data"""
-        return Vitals(await self.api.async_request("vitals"))
+        return Vitals(
+            await self.api.async_request("vitals"),
+            split_phase=self.split_phase,
+        )
 
     async def async_get_lifetime(self) -> dict:
         """Get 'lifetime' data"""

--- a/tests/test_wall_connector.py
+++ b/tests/test_wall_connector.py
@@ -77,6 +77,14 @@ async def test_vitals_request_modern_relay_fields(aresponses):
         assert vitals.relay_coil_v == 12.0
         assert vitals.evse_not_ready_reasons == [4, 8]
 
+@pytest.mark.asyncio
+async def test_vitals_request_split_phase(aresponses):
+    add_valid_vitals_response(aresponses)
+    async with aiohttp.ClientSession() as session:
+        wall_connector = WallConnector("anyhost", session=session, split_phase=True)
+        vitals = await wall_connector.async_get_vitals()
+        assert vitals.total_power_w == 114.4
+
 
 @pytest.mark.asyncio
 async def test_lifetime_request(aresponses):


### PR DESCRIPTION
## Summary

This changes how `total_power_w` is calculated so it can support both three-phase and split-phase wall connector installs without exposing multiple power properties.

## What changed

- keep a single `Vitals.total_power_w` property
- add a `split_phase` boolean option to `WallConnector`
- calculate `total_power_w` from:
  - the three-phase sum by default
  - `grid_v * vehicle_current_a` when `split_phase=True`
- update test coverage for both default three-phase and split-phase behavior

## Why

The previous implementation assumed a single calculation model for all installs. That works for some setups, but not for split-phase wiring where using the per-phase readings can overstate total power.

With this change, the library keeps the existing `total_power_w` API, preserves backward compatibility by defaulting to three-phase behavior, and allows split-phase users to opt into the correct calculation.

Fixes #18