### PR TITLE
Add WiFi status support and complete field coverage for newer Wall Connector firmware

### DIFF
--- a/tesla_wall_connector/version.py
+++ b/tesla_wall_connector/version.py
@@ -21,3 +21,13 @@ class Version:
     def serial_number(self) -> str:
         """Serial Number"""
         return self.raw_data["serial_number"]
+
+    @property
+    def git_branch(self) -> str:
+        """Git branch in the installed firmware build."""
+        return self.raw_data["git_branch"]
+
+    @property
+    def web_service(self) -> str:
+        """Configured Tesla backend web service endpoint."""
+        return self.raw_data["web_service"]

--- a/tesla_wall_connector/vitals.py
+++ b/tesla_wall_connector/vitals.py
@@ -80,8 +80,24 @@ class Vitals:
 
     @property
     def relay_coil_v(self) -> float:
-        """Relay coil voltage"""
-        return self.raw_data["relay_coil_v"]
+        """Relay coil voltage (alias).
+
+        Newer firmware exposes two relays as relay_k1_v and relay_k2_v.
+        Older firmware exposes relay_coil_v only.
+        """
+        if "relay_coil_v" in self.raw_data:
+            return self.raw_data["relay_coil_v"]
+        return self.relay_k1_v
+
+    @property
+    def relay_k1_v(self) -> float:
+        """Relay K1 voltage"""
+        return self.raw_data["relay_k1_v"]
+
+    @property
+    def relay_k2_v(self) -> float:
+        """Relay K2 voltage"""
+        return self.raw_data["relay_k2_v"]
 
     @property
     def pcba_temp_c(self) -> float:
@@ -150,3 +166,8 @@ class Vitals:
     def current_alerts(self) -> typing.List[str]:
         """Current alerts"""
         return self.raw_data["current_alerts"]
+
+    @property
+    def evse_not_ready_reasons(self) -> typing.List[int]:
+        """Reasons for EVSE not being ready."""
+        return self.raw_data.get("evse_not_ready_reasons", [])

--- a/tesla_wall_connector/wall_connector.py
+++ b/tesla_wall_connector/wall_connector.py
@@ -6,6 +6,7 @@ from .api import API
 from .lifetime import Lifetime
 from .version import Version
 from .vitals import Vitals
+from .wifi_status import WifiStatus
 
 
 class WallConnector:
@@ -28,6 +29,10 @@ class WallConnector:
     async def async_get_version(self) -> dict:
         """Get version information"""
         return Version(await self.api.async_request("version"))
+
+    async def async_get_wifi_status(self) -> dict:
+        """Get wifi status information"""
+        return WifiStatus(await self.api.async_request("wifi_status"))
 
     async def __aenter__(self):
         return self

--- a/tesla_wall_connector/wifi_status.py
+++ b/tesla_wall_connector/wifi_status.py
@@ -1,0 +1,61 @@
+"""Wifi status data class for Tesla Wall Connector."""
+import base64
+import binascii
+
+
+class WifiStatus:
+    """Object holding wifi status data for Tesla Wall Connector."""
+
+    def __init__(self, raw_data: dict):
+        self.raw_data = raw_data
+
+    @property
+    def wifi_ssid(self) -> str:
+        """Wifi SSID reported by the Wall Connector.
+
+        Tesla reports this value base64-encoded, but some firmware variants
+        may already return plaintext. Decode when possible and otherwise return
+        the raw value.
+        """
+        raw_ssid = self.raw_data["wifi_ssid"]
+        if not raw_ssid:
+            return raw_ssid
+        try:
+            return base64.b64decode(raw_ssid, validate=True).decode("utf-8")
+        except (binascii.Error, UnicodeDecodeError, ValueError):
+            return raw_ssid
+
+    @property
+    def wifi_signal_strength(self) -> int:
+        """Wifi signal strength."""
+        return self.raw_data["wifi_signal_strength"]
+
+    @property
+    def wifi_rssi(self) -> int:
+        """Wifi received signal strength indicator."""
+        return self.raw_data["wifi_rssi"]
+
+    @property
+    def wifi_snr(self) -> int:
+        """Wifi signal-to-noise ratio."""
+        return self.raw_data["wifi_snr"]
+
+    @property
+    def wifi_connected(self) -> bool:
+        """Whether wifi is connected."""
+        return self.raw_data["wifi_connected"]
+
+    @property
+    def wifi_infra_ip(self) -> str:
+        """Wifi infrastructure IP address."""
+        return self.raw_data["wifi_infra_ip"]
+
+    @property
+    def internet(self) -> bool:
+        """Whether Wall Connector has internet connectivity."""
+        return self.raw_data["internet"]
+
+    @property
+    def wifi_mac(self) -> str:
+        """Wifi MAC address."""
+        return self.raw_data["wifi_mac"]

--- a/tests/test_wall_connector.py
+++ b/tests/test_wall_connector.py
@@ -45,7 +45,37 @@ async def test_vitals_request(aresponses):
         assert vitals.config_status == 5
         assert vitals.evse_state == 1
         assert vitals.current_alerts == ["alert1", "alert2"]
+        assert vitals.evse_not_ready_reasons == []
         assert vitals.total_power_w == 241.7
+
+
+@pytest.mark.asyncio
+async def test_vitals_request_modern_relay_fields(aresponses):
+    aresponses.add(
+        "anyhost",
+        "/api/1/vitals",
+        "GET",
+        aresponses.Response(
+            status=200,
+            headers={"Content-Type": "application/json"},
+            text="""
+                {
+                    "relay_k1_v":12.0,
+                    "relay_k2_v":0.0,
+                    "evse_not_ready_reasons":[4,8]
+                }
+                """,
+        ),
+    )
+
+    async with aiohttp.ClientSession() as session:
+        wall_connector = WallConnector("anyhost", session=session)
+        vitals = await wall_connector.async_get_vitals()
+        assert vitals.relay_k1_v == 12.0
+        assert vitals.relay_k2_v == 0.0
+        # Backward-compatible alias maps to relay_k1_v when relay_coil_v is absent.
+        assert vitals.relay_coil_v == 12.0
+        assert vitals.evse_not_ready_reasons == [4, 8]
 
 
 @pytest.mark.asyncio
@@ -101,8 +131,10 @@ async def test_version_request(aresponses):
             text="""
                 {
                     "firmware_version":"21.29.1+g4152353e50f744",
+                    "git_branch":"HEAD",
                     "part_number":"1529455-02-D",
-                    "serial_number":"ACB12345678901"
+                    "serial_number":"ACB12345678901",
+                    "web_service":"h3-hermes-prd.sn.tesla.services"
                 }
                 """,
         ),
@@ -112,8 +144,10 @@ async def test_version_request(aresponses):
         wall_connector = WallConnector("anyhost", session=session)
         version = await wall_connector.async_get_version()
         assert version.firmware_version == "21.29.1+g4152353e50f744"
+        assert version.git_branch == "HEAD"
         assert version.part_number == "1529455-02-D"
         assert version.serial_number == "ACB12345678901"
+        assert version.web_service == "h3-hermes-prd.sn.tesla.services"
 
 
 @pytest.mark.asyncio

--- a/tests/test_wall_connector.py
+++ b/tests/test_wall_connector.py
@@ -117,6 +117,73 @@ async def test_version_request(aresponses):
 
 
 @pytest.mark.asyncio
+async def test_wifi_status_request(aresponses):
+    aresponses.add(
+        "anyhost",
+        "/api/1/wifi_status",
+        "GET",
+        aresponses.Response(
+            status=200,
+            headers={"Content-Type": "application/json"},
+            text="""
+                {
+                    "wifi_ssid":"VGVzdE5ldHdvcms=",
+                    "wifi_signal_strength":44,
+                    "wifi_rssi":-68,
+                    "wifi_snr":18,
+                    "wifi_connected":true,
+                    "wifi_infra_ip":"192.168.1.50",
+                    "internet":true,
+                    "wifi_mac":"AA:BB:CC:DD:EE:FF"
+                }
+                """,
+        ),
+    )
+
+    async with aiohttp.ClientSession() as session:
+        wall_connector = WallConnector("anyhost", session=session)
+        wifi_status = await wall_connector.async_get_wifi_status()
+        assert wifi_status.wifi_ssid == "TestNetwork"
+        assert wifi_status.wifi_signal_strength == 44
+        assert wifi_status.wifi_rssi == -68
+        assert wifi_status.wifi_snr == 18
+        assert wifi_status.wifi_connected is True
+        assert wifi_status.wifi_infra_ip == "192.168.1.50"
+        assert wifi_status.internet is True
+        assert wifi_status.wifi_mac == "AA:BB:CC:DD:EE:FF"
+
+
+@pytest.mark.asyncio
+async def test_wifi_status_request_non_base64_ssid(aresponses):
+    aresponses.add(
+        "anyhost",
+        "/api/1/wifi_status",
+        "GET",
+        aresponses.Response(
+            status=200,
+            headers={"Content-Type": "application/json"},
+            text="""
+                {
+                    "wifi_ssid":"MyPlainNetwork",
+                    "wifi_signal_strength":44,
+                    "wifi_rssi":-68,
+                    "wifi_snr":18,
+                    "wifi_connected":true,
+                    "wifi_infra_ip":"192.168.1.50",
+                    "internet":true,
+                    "wifi_mac":"AA:BB:CC:DD:EE:FF"
+                }
+                """,
+        ),
+    )
+
+    async with aiohttp.ClientSession() as session:
+        wall_connector = WallConnector("anyhost", session=session)
+        wifi_status = await wall_connector.async_get_wifi_status()
+        assert wifi_status.wifi_ssid == "MyPlainNetwork"
+
+
+@pytest.mark.asyncio
 async def test_internal_session(aresponses):
     add_valid_vitals_response(aresponses)
     async with WallConnector("anyhost") as wall_connector:


### PR DESCRIPTION
## Summary
This PR adds WiFi API support and fills missing fields from newer Tesla Wall Connector firmware.

## What changed
- Added `async_get_wifi_status()` and new `WifiStatus` model
- Added SSID base64 decoding with plaintext fallback
- Exposed missing fields:
  - `Vitals`: `relay_k1_v`, `relay_k2_v`, `evse_not_ready_reasons` (#13)
  - `Version`: `git_branch`, `web_service`
- Kept backward compatibility with `relay_coil_v` alias behavior
- Added/updated tests (using sanitized fixture values)

Fixes #6 