### PR TITLE
Remove library-level retry to prevent file descriptor exhaustion

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,8 +8,7 @@ license = { text = "MIT" }
 authors = [{ name = "Einar Bragi Hauksson", email = "einar.hauksson@gmail.com" }]
 keywords = ["tesla", "wall connector"]
 dependencies = [
-  "aiohttp>=3.14,<4",
-  "backoff>=1.11,<2",
+  "aiohttp>=3.14,<4"
 ]
 
 [project.urls]

--- a/tesla_wall_connector/__init__.py
+++ b/tesla_wall_connector/__init__.py
@@ -1,5 +1,5 @@
 """Asynchronous Python client for Tesla Wall Connector"""
 
-from .wall_connector import WallConnector  # noqa
+from .wall_connector import WallConnector
 
-VERSION = "0.1.0"
+__all__ = ["WallConnector"]

--- a/tesla_wall_connector/api.py
+++ b/tesla_wall_connector/api.py
@@ -7,7 +7,6 @@ from json.decoder import JSONDecodeError
 
 import aiohttp
 import asyncio
-import backoff
 
 from .exceptions import (
     WallConnectorConnectionError,
@@ -29,11 +28,6 @@ class API:
         """Construct a Wall Charger URL for a specified endpoint"""
         return f"http://{self.host}/api/1/{endpoint}"
 
-    @backoff.on_exception(
-        backoff.expo,
-        (WallConnectorConnectionTimeoutError, WallConnectorConnectionError),
-        max_tries=3,
-    )
     async def async_request(self, endpoint: str) -> dict:
         """Make an asynchronous request to a Tesla Wall Connector endpoint
         Args:

--- a/tests/test_wall_connector.py
+++ b/tests/test_wall_connector.py
@@ -241,9 +241,6 @@ async def test_timeout(aresponses):
         await asyncio.sleep(0.2)
         return get_valid_vitals_response_handler(aresponses)
 
-    # Backoff will try 3 times
-    aresponses.add("anyhost", "/api/1/vitals", "GET", response_handler)
-    aresponses.add("anyhost", "/api/1/vitals", "GET", response_handler)
     aresponses.add("anyhost", "/api/1/vitals", "GET", response_handler)
 
     async with aiohttp.ClientSession() as session:

--- a/uv.lock
+++ b/uv.lock
@@ -169,15 +169,6 @@ wheels = [
 ]
 
 [[package]]
-name = "backoff"
-version = "1.11.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/27/d2/9d2d0f0d6bbe17628b031040b1dadaee616286267e660ad5286a5ed657da/backoff-1.11.1.tar.gz", hash = "sha256:ccb962a2378418c667b3c979b504fdeb7d9e0d29c0579e3b13b86467177728cb", size = 14883, upload-time = "2021-07-14T13:56:15.748Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d7/dd/88df7d5b2077825d6757a674123062c6e7545cc61556b42739e8757b7b65/backoff-1.11.1-py2.py3-none-any.whl", hash = "sha256:61928f8fa48d52e4faa81875eecf308eccfb1016b018bb6bd21e05b5d90a96c5", size = 13141, upload-time = "2021-07-14T13:56:13.096Z" },
-]
-
-[[package]]
 name = "bandit"
 version = "1.9.4"
 source = { registry = "https://pypi.org/simple" }
@@ -842,7 +833,6 @@ version = "1.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
-    { name = "backoff" },
 ]
 
 [package.dev-dependencies]
@@ -858,10 +848,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [
-    { name = "aiohttp", specifier = ">=3.14,<4" },
-    { name = "backoff", specifier = ">=1.11,<2" },
-]
+requires-dist = [{ name = "aiohttp", specifier = ">=3.14,<4" }]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
Home Assistant's DataUpdateCoordinator already retries on the configured poll interval. The library's backoff decorator multiplied failed connections when the device was offline — up to 6 socket attempts per 30-second poll cycle — contributing to fd exhaustion and HA crashes.

Also replaces deprecated async_timeout with stdlib asyncio.timeout and drops the backoff dependency entirely.

Decision for the maintainer: Since this duplication of retries is only noticeable on HA, and since ostensibly this was written to be generic (even though it targets HA explicitly), are you fine with losing the retry logic internal to this library and allowing HA to handle it since it's the main use case for this library? 

Tested on my local instance and it does clear up the excess file descriptor exhaustion.