### PR TITLE
fix: better timeout handling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ license = { text = "MIT" }
 authors = [{ name = "Einar Bragi Hauksson", email = "einar.hauksson@gmail.com" }]
 keywords = ["tesla", "wall connector"]
 dependencies = [
-  "aiohttp>=3.14,<4"
+  "aiohttp>=3.13.5,<4"
 ]
 
 [project.urls]

--- a/tesla_wall_connector/api.py
+++ b/tesla_wall_connector/api.py
@@ -6,7 +6,6 @@ import socket
 from json.decoder import JSONDecodeError
 
 import aiohttp
-import asyncio
 
 from .exceptions import (
     WallConnectorConnectionError,
@@ -18,7 +17,9 @@ from .exceptions import (
 class API:
     """This class provides an abstraction for reading data from a Tesla Wall Connector"""
 
-    def __init__(self, host: str, session: aiohttp.ClientSession, timeout: float = 2):
+    READ_TIMEOUT_MULTIPLIER = 3
+
+    def __init__(self, host: str, session: aiohttp.ClientSession, timeout: float):
         self.host = host
         self.session = session
         self.timeout = timeout
@@ -30,6 +31,13 @@ class API:
 
     async def async_request(self, endpoint: str) -> dict:
         """Make an asynchronous request to a Tesla Wall Connector endpoint
+
+        The wall connector can take several seconds to start sending a
+        response even after the TCP session is established. Treat the
+        user-provided timeout as the connect budget and give reads more
+        headroom so slow-but-progressing responses are not cancelled
+        early.
+
         Args:
             endpoint: Endpoint string such as 'vitals' or 'lifetime'
 
@@ -41,14 +49,29 @@ class API:
             Data for the given endpoint
         """
         try:
-            async with asyncio.timeout(self.timeout):
-                async with self.session.get(self.get_url(endpoint)) as response:
-                    response.raise_for_status()
-                    return await self.decode_response(response)
+            request_timeout = aiohttp.ClientTimeout(
+                total=None,
+                connect=self.timeout,
+                sock_connect=self.timeout,
+                sock_read=self.timeout * self.READ_TIMEOUT_MULTIPLIER,
+            )
+            async with self.session.get(self.get_url(endpoint), timeout=request_timeout) as response:
+                response.raise_for_status()
+                return await self.decode_response(response)
+        except aiohttp.ConnectionTimeoutError as ex:
+            raise WallConnectorConnectionTimeoutError(
+                f"Connection timeout while opening socket to Wall Connector at {self.host}"
+            ) from ex
+        except aiohttp.SocketTimeoutError as ex:
+            raise WallConnectorConnectionTimeoutError(
+                f"Read timeout while waiting for response from Wall Connector at {self.host}"
+            ) from ex
         except TimeoutError as ex:
             raise WallConnectorConnectionTimeoutError(
-                f"Timeout while connecting to Wall Connector at {self.host}"
+                f"Timeout while communicating with Wall Connector at {self.host}"
             ) from ex
+        except aiohttp.ClientConnectorError as ex:
+            raise WallConnectorConnectionError(f"TCP connection to Wall Connector at {self.host} failed: {ex}") from ex
         except (aiohttp.ClientError, socket.gaierror) as ex:
             raise WallConnectorConnectionError(
                 f"Error while communicating with Wall Connector at {self.host}: {ex}"

--- a/tesla_wall_connector/wall_connector.py
+++ b/tesla_wall_connector/wall_connector.py
@@ -15,14 +15,12 @@ class WallConnector:
     def __init__(
         self,
         host: str,
-        timeout: float = 1,
+        timeout: float = 5,
         session: ClientSession | None = None,
         split_phase: bool = False,
     ):
-        if session is None:
-            session = ClientSession()
-            self._session = session
-        self.api = API(host, session, timeout)
+        self._session = ClientSession() if session is None else session
+        self.api = API(host, self._session, timeout)
         self.split_phase = split_phase
 
     async def async_get_vitals(self) -> Vitals:

--- a/tests/test_wall_connector.py
+++ b/tests/test_wall_connector.py
@@ -238,7 +238,7 @@ async def test_internal_session(aresponses):
 @pytest.mark.asyncio
 async def test_timeout(aresponses):
     async def response_handler(_):
-        await asyncio.sleep(0.2)
+        await asyncio.sleep(0.4)
         return get_valid_vitals_response_handler(aresponses)
 
     aresponses.add("anyhost", "/api/1/vitals", "GET", response_handler)
@@ -247,6 +247,20 @@ async def test_timeout(aresponses):
         wall_connector = WallConnector("anyhost", timeout=0.1, session=session)
         with pytest.raises(WallConnectorConnectionTimeoutError):
             assert await wall_connector.async_get_vitals()
+
+
+@pytest.mark.asyncio
+async def test_slow_response_within_extended_read_timeout(aresponses):
+    async def response_handler(_):
+        await asyncio.sleep(0.2)
+        return get_valid_vitals_response_handler(aresponses)
+
+    aresponses.add("anyhost", "/api/1/vitals", "GET", response_handler)
+
+    async with aiohttp.ClientSession() as session:
+        wall_connector = WallConnector("anyhost", timeout=0.1, session=session)
+        vitals = await wall_connector.async_get_vitals()
+        assert vitals.contactor_closed is False
 
 
 @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -848,7 +848,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "aiohttp", specifier = ">=3.14,<4" }]
+requires-dist = [{ name = "aiohttp", specifier = ">=3.13.5,<4" }]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary

- Replace the single overall request timeout with an `aiohttp.ClientTimeout`
- Treat the configured timeout as the connect/socket-open budget
- Allow a longer socket read window for slow Wall Connector responses
- Raise more specific timeout errors for connection vs read timeouts
- Increase the default Wall Connector timeout from `1s` to `5s`
- Simplify session assignment in `WallConnector`
- Add test coverage for slow responses that should still succeed within the extended read timeout